### PR TITLE
Add I2S Slave Support For Teensy 4.0

### DIFF
--- a/input_i2s_f32.cpp
+++ b/input_i2s_f32.cpp
@@ -273,8 +273,10 @@ void AudioInputI2Sslave_F32::begin(void)
 {
 	dma.begin(true); // Allocate the DMA channel first
 
-	AudioOutputI2Sslave_F32::config_i2s();
+	//block_left_1st = NULL;
+	//block_right_1st = NULL;
 
+	AudioOutputI2Sslave_F32::config_i2s();
 #if defined(KINETISK)
 	CORE_PIN13_CONFIG = PORT_PCR_MUX(4); // pin 13, PTC5, I2S0_RXD0
 

--- a/input_i2s_f32.cpp
+++ b/input_i2s_f32.cpp
@@ -273,10 +273,8 @@ void AudioInputI2Sslave_F32::begin(void)
 {
 	dma.begin(true); // Allocate the DMA channel first
 
-	//block_left_1st = NULL;
-	//block_right_1st = NULL;
-
 	AudioOutputI2Sslave_F32::config_i2s();
+
 #if defined(KINETISK)
 	CORE_PIN13_CONFIG = PORT_PCR_MUX(4); // pin 13, PTC5, I2S0_RXD0
 
@@ -293,12 +291,34 @@ void AudioInputI2Sslave_F32::begin(void)
 	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
 
 	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_I2S0_RX);
-	update_responsibility = update_setup();
-	dma.enable();
 
 	I2S0_RCSR |= I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
 	I2S0_TCSR |= I2S_TCSR_TE | I2S_TCSR_BCE; // TX clock enable, because sync'd to TX
-	dma.attachInterrupt(isr);
+
+#elif defined(__IMXRT1062__)
+	CORE_PIN8_CONFIG  = 3;  //1:RX_DATA0
+	IOMUXC_SAI1_RX_DATA0_SELECT_INPUT = 2;
+
+	dma.TCD->SADDR = (void *)((uint32_t)&I2S1_RDR0 + 0);
+	dma.TCD->SOFF = 0;
+	dma.TCD->ATTR = DMA_TCD_ATTR_SSIZE(2) | DMA_TCD_ATTR_DSIZE(2);
+	dma.TCD->NBYTES_MLNO = 4;
+	dma.TCD->SLAST = 0;
+	dma.TCD->DADDR = i2s_rx_buffer;
+	dma.TCD->DOFF = 4;
+	dma.TCD->CITER_ELINKNO = sizeof(i2s_rx_buffer) / 4;
+	dma.TCD->DLASTSGA = -sizeof(i2s_rx_buffer);
+	dma.TCD->BITER_ELINKNO = sizeof(i2s_rx_buffer) / 4;
+	dma.TCD->CSR = DMA_TCD_CSR_INTHALF | DMA_TCD_CSR_INTMAJOR;
+	dma.triggerAtHardwareEvent(DMAMUX_SOURCE_SAI1_RX);
+
+	// Reset then enable RX (matches PJRC slave begin pattern)
+	I2S1_RCSR = 0;
+	I2S1_RCSR = I2S_RCSR_RE | I2S_RCSR_BCE | I2S_RCSR_FRDE | I2S_RCSR_FR;
 #endif
+
+	update_responsibility = update_setup();
+	dma.enable();
+	dma.attachInterrupt(isr);
 }
 


### PR DESCRIPTION
Looks like the `AudioInputI2Sslave_F32` is targeting an older teensy 3 board. Add a new logic section to support Teensy 4.0 board. I compared the logic used in the PJRC audio library and added this logic more so as an educated guess. It my testing it does work with some glitches though, I am probably testing this all wrong though as I don't have an oscilloscope. 

Probably would also need the design tool with this i2sslaveinput drag and drop element. Didn't add that code yet as I think this slave code needs more work.

For reference: this is the code I was using in the Arduino sketch when I tested this. I was sending over 16 bit at 48 khz:
```
#include "OpenAudio_ArduinoLibrary.h"
#include "AudioStream_F32.h"
#include "USB_Audio_F32.h"
#include <Audio.h>
#include <Wire.h>
#include <SPI.h>
#include <SD.h>
#include <SerialFlash.h>

AudioInputI2Sslave_F32       audioInI2S1;
AudioOutputUSB_F32           audioOutUSB1;
AudioConnection_F32          patchCord1(audioInI2S1, 0, audioOutUSB1, 0);
AudioConnection_F32          patchCord2(audioInI2S1, 1, audioOutUSB1, 1);

void setup() {
  AudioMemory(30);  
  AudioMemory_F32(30);
}

void loop() {
}
```