### PR TITLE
Avoid NANs when no blocks have been processed

### DIFF
--- a/analyze_rms_f32.cpp
+++ b/analyze_rms_f32.cpp
@@ -64,5 +64,5 @@ float AudioAnalyzeRMS_F32::read(void)  {
     float32_t num = (float32_t)count;
     count = 0;
     __enable_irq();
-    return sqrtf(sum / (num * (float32_t)block_size));
+    return num? sqrtf(sum / (num * (float32_t)block_size)): 0;
 }


### PR DESCRIPTION
I have had situations where in AudioAnalyzeRMS_F32 no blocks have been processed, resulting in a division by zero on read(). The resulting NANs have been persistent for reasons unknown to me, totally blowing up DSP processing.
The patch fixes potential divisions by zero.